### PR TITLE
Adds spawnOptions to grunt task options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Cucumber profile to use
 ####format
 Type: `String`
 
+Cucumber formatter
+
 #### spawnOptions
 Type: `Object`
 
 [Options](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) to pass to nodeJS child process spawn 
-
-Cucumber formatter

--- a/README.md
+++ b/README.md
@@ -68,4 +68,9 @@ Cucumber profile to use
 ####format
 Type: `String`
 
+#### spawnOptions
+Type: `Object`
+
+[Options](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) to pass to nodeJS child process spawn 
+
 Cucumber formatter

--- a/tasks/cucumber.coffee
+++ b/tasks/cucumber.coffee
@@ -17,9 +17,10 @@ module.exports = (grunt) ->
 
     command = builder.build this.data.features, this.options
     dir     = builder.directory()
+    
+    spawnOptions = builder.getSpawnOptions this.options()
 
     grunt.verbose.writeln 'Starting cucumber (target: ' + this.target.cyan + ') in ' + dir.cyan
     grunt.verbose.writeln 'Running: ' + command.cyan
 
-
-    cucumber.run(command, this.async());
+    cucumber.run(command, spawnOptions, this.async());

--- a/tasks/lib/builder.coffee
+++ b/tasks/lib/builder.coffee
@@ -106,4 +106,15 @@ exports.init = (grunt) ->
 
     return prefix() + ' ' + command() + ' ' + buildOptions() + ' ' + directory
 
+  #
+  # Returns the spawn options to be used for node child_process.exec
+  #
+  # @param Object options
+  #
+  exports.getSpawnOptions = (options) ->
+    spawnOptions = {}
+    spawnOptions = options.spawnOptions unless typeof options.spawnOptions == 'undefined'
+
+    return spawnOptions
+
   return exports

--- a/tasks/lib/cucumber.coffee
+++ b/tasks/lib/cucumber.coffee
@@ -16,11 +16,12 @@ exports.init = (grunt) ->
   # Runs cucumber command with callback
   #
   # @param String command
+  # @param String spawnOptions
   # @param Function callback
   #
-  exports.run = (command, callback) ->
+  exports.run = (command, spawnOptions, callback) ->
 
-    exec command, (err, stdout, stderr) ->
+    exec command, spawnOptions, (err, stdout, stderr) ->
       grunt.log.write(stdout) if stdout
       grunt.fatal(err) if err
       callback()


### PR DESCRIPTION
Added "spawnOptions" to grunt task options to control the nodeJS child process [options](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) of the cucumber

Fixes [this](https://github.com/jrcryer/grunt-rcukes/issues/2) issue
